### PR TITLE
Add minimal vocabulary learning platform skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# English Teaching Platform Skeleton
+
+This repository contains a minimal Python implementation that addresses
+key features from the project description:
+
+* Upload English-Uzbek vocabulary lists.
+* Provide flashcards from the uploaded vocabulary.
+* Offer a simple contest mode selecting random words.
+* Schedule reviews using a naive spaced-repetition algorithm.
+* Store passages with clickable words, phrases and idioms.
+
+Run the tests with:
+
+```bash
+pytest
+```
+
+This is only a starting point for a full platform.

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -1,0 +1,28 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from vocab_platform import VocabularyPlatform
+
+def test_upload_and_flashcards():
+    p = VocabularyPlatform()
+    p.upload_vocab([{'english': 'cat', 'uzbek': 'mushuk'}])
+    assert ('cat', 'mushuk') in p.get_flashcards()
+
+def test_contest_and_schedule():
+    p = VocabularyPlatform()
+    words = [
+        {'english': 'cat', 'uzbek': 'mushuk'},
+        {'english': 'dog', 'uzbek': 'it'},
+        {'english': 'bird', 'uzbek': 'qush'},
+    ]
+    p.upload_vocab(words)
+    contest_words = p.contest(n=2)
+    assert len(contest_words) == 2
+    schedule = p.schedule_reviews()
+    assert set(schedule.keys()) == {w['english'] for w in words}
+
+def test_passage_storage():
+    p = VocabularyPlatform()
+    p.upload_passage('Hello world', ['world'], ['hello world'], [])
+    passage = p.get_passage()
+    assert passage['text'] == 'Hello world'
+    assert passage['words'] == ['world']

--- a/vocab_platform.py
+++ b/vocab_platform.py
@@ -1,0 +1,50 @@
+import random
+import datetime
+from typing import List, Dict, Tuple, Optional
+
+class VocabularyPlatform:
+    """Simple in-memory platform for English-Uzbek vocabulary learning."""
+    def __init__(self) -> None:
+        self.vocab: Dict[str, str] = {}
+        self.passage: Optional[Dict[str, object]] = None
+
+    def upload_vocab(self, words: List[Dict[str, str]]) -> None:
+        """Upload vocabulary list.
+
+        Args:
+            words: List of dicts with keys 'english' and 'uzbek'.
+        """
+        for w in words:
+            eng = w.get('english')
+            uz = w.get('uzbek')
+            if eng and uz:
+                self.vocab[eng] = uz
+
+    def get_flashcards(self) -> List[Tuple[str, str]]:
+        """Return vocabulary as list of flashcards."""
+        return list(self.vocab.items())
+
+    def contest(self, n: int = 5) -> List[Tuple[str, str]]:
+        """Return *n* random vocabulary items for contest mode."""
+        if not self.vocab:
+            raise ValueError("No vocabulary available")
+        sample = random.sample(list(self.vocab.items()), min(n, len(self.vocab)))
+        return sample
+
+    def schedule_reviews(self) -> Dict[str, datetime.datetime]:
+        """Very naive spaced-repetition schedule: review all words tomorrow."""
+        tomorrow = datetime.datetime.now() + datetime.timedelta(days=1)
+        return {word: tomorrow for word in self.vocab}
+
+    def upload_passage(self, text: str, words: List[str], phrases: List[str], idioms: List[str]) -> None:
+        """Store passage with associated clickable vocabulary."""
+        self.passage = {
+            'text': text,
+            'words': words,
+            'phrases': phrases,
+            'idioms': idioms,
+        }
+
+    def get_passage(self) -> Optional[Dict[str, object]]:
+        """Return stored passage information."""
+        return self.passage


### PR DESCRIPTION
## Summary
- implement `VocabularyPlatform` class to upload vocabulary, flashcards, contests, spaced reviews, and passages
- document project with README and basic usage
- include tests covering core features

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897a1db91a8832a82cbed494c1bdf04